### PR TITLE
switch to FFI::Platypus

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,7 +7,7 @@ all_from 'lib/Phash/FFI.pm';
 repository 'git://github.com/gugod/Phash-FFI.git';
 
 requires
-    'FFI::Raw'      => '0.32',
+    'FFI::Platypus' => '0.12',
     'FFI::CheckLib' => '0.03';
 
 tests 't/*.t';

--- a/lib/Phash/FFI.pm
+++ b/lib/Phash/FFI.pm
@@ -3,26 +3,19 @@ use strict;
 use warnings;
 our $VERSION = "0.02";
 
-use FFI::Raw;
+use FFI::Platypus;
 use FFI::CheckLib;
 
-use constant _libphash => find_lib(lib => "pHash");
+my $ffi = FFI::Platypus->new;
+$ffi->lib(find_lib(lib => "pHash"));
 
-use constant {
-    _ph_dct_imagehash => FFI::Raw->new(
-        _libphash,
-        'ph_dct_imagehash',
-        FFI::Raw::int,
-        FFI::Raw::str,
-        FFI::Raw::ptr,
-    )
-};
+$ffi->attach( [ ph_dct_imagehash => '_ph_dct_imagehash' ] => [ 'string', 'uint64*' ] => 'int' );
 
 sub dct_imagehash {
     my ($file_path) = @_;
-    my $hash = FFI::Raw::memptr(8);
-    my $rv = _ph_dct_imagehash->call($file_path, $hash);
-    return unpack("Q", $hash->tostr(8));
+    my $hash;
+    my $rv = _ph_dct_imagehash($file_path, \$hash);
+    return $hash;
 }
 
 1;


### PR DESCRIPTION
I noticed that you are using `FFI::Raw` in `Phash::FFI` and I thought you might be interested in `FFI::Platypus`.  As you can see the code is less complicated because Platypus supports pointers to integers (even 64bit ones on 32bit Perls).  It should also considerably faster if you make multiple calls to dct_imagehash because there is no unnecessary method dispatch (_ph_dct_imagehash is an xsub which is much faster than the FFI::Raw call notation).
