### PR TITLE
use the correct types for arguments on ph_hamming_distance

### DIFF
--- a/lib/Phash/FFI.pm
+++ b/lib/Phash/FFI.pm
@@ -10,7 +10,7 @@ my $ffi = FFI::Platypus->new;
 $ffi->find_lib(lib => "pHash");
 
 $ffi->attach( [ ph_dct_imagehash => '_ph_dct_imagehash' ] => [ 'string', 'uint64*' ] => 'int' );
-$ffi->attach([ ph_hamming_distance => 'ph_hamming_distance' ] => [ 'int', 'int' ] => 'int');
+$ffi->attach([ ph_hamming_distance => 'ph_hamming_distance' ] => [ 'uint64', 'uint64' ] => 'int');
 
 sub dct_imagehash {
     my ($file_path) = @_;


### PR DESCRIPTION
This may fix rt#120345.  I am basing this on the Ruby implementation:

https://github.com/toy/pHash/blob/master/lib/phash/image.rb#L18

Caveat being that I haven't actually tested this myself.  I suggest that someone test with the script in the RT issue.  I am not able to test where I am atm.